### PR TITLE
Refactor : entity 연관관계 개선, entity 분리

### DIFF
--- a/src/bookmark/bookmark.entity.ts
+++ b/src/bookmark/bookmark.entity.ts
@@ -1,13 +1,9 @@
-import { Entity, PrimaryColumn, Generated, ManyToOne, JoinColumn } from 'typeorm';
+import { Entity, ManyToOne, JoinColumn } from 'typeorm';
 import User from '../user/user.entity';
 import Recipe from '../recipe/recipe.entity';
 
 @Entity({ name: 'BOOKMARK' })
 export default class Bookmark {
-	@PrimaryColumn({ name: 'BOOKMARK_ID', type: 'bigint', unsigned: true })
-	@Generated('increment')
-	id: number;
-
 	@ManyToOne(() => Recipe, (recipe) => recipe.id, { lazy: true, nullable: false, primary: true })
 	@JoinColumn({ name: 'RECIPE_ID' })
 	recipe: Recipe;

--- a/src/recipe-description/recipe-description.entity.ts
+++ b/src/recipe-description/recipe-description.entity.ts
@@ -1,0 +1,17 @@
+import { Entity, ManyToOne, Column } from 'typeorm';
+import Recipe from '../recipe/recipe.entity';
+
+@Entity({ name: 'RECIPE_DESCRIPTION' })
+export default class Description {
+	@ManyToOne(() => Recipe, (recipe) => recipe.descriptions, { lazy: true, primary: true })
+	recipe: Recipe;
+
+	@Column({ name: 'IMAGE_DESCRIPTION', type: 'varchar', length: 900, nullable: false })
+	imageDescription: string;
+
+	@Column({ name: 'IMAGE_URL', type: 'varchar', length: 2048, nullable: false })
+	imageUrl: string;
+
+	@Column({ name: 'DESCRIPTION_ORDER', type: 'smallint', nullable: false })
+	descriptionOrder: number;
+}

--- a/src/recipe-ingredient/recipe-ingredient.entity.ts
+++ b/src/recipe-ingredient/recipe-ingredient.entity.ts
@@ -1,0 +1,21 @@
+import { Column, Entity, ManyToOne, JoinColumn, PrimaryColumn, Generated } from 'typeorm';
+
+import Recipe from '../recipe/recipe.entity';
+import Ingredient from '../ingredient/ingredient.entity';
+
+@Entity({ name: 'RECIPE_INGREDIENT' })
+export default class RecipeIngredient {
+	@ManyToOne(() => Recipe, (recipe) => recipe.ingredients, { lazy: true, primary: true })
+	@JoinColumn({ name: 'RECIPE_ID' })
+	recipe: Recipe;
+
+	@ManyToOne(() => Ingredient, (ingredient) => ingredient.id, { lazy: true, primary: true })
+	@JoinColumn({ name: 'INGREDIENT_ID' })
+	ingredient: Ingredient;
+
+	@Column({ name: 'AMOUNT', type: 'int', nullable: false })
+	amount: number;
+
+	@Column({ name: 'SCALE', type: 'varchar', length: 10, nullable: false })
+	scale: string;
+}

--- a/src/recipe-tag/recipe-tag.entity.ts
+++ b/src/recipe-tag/recipe-tag.entity.ts
@@ -1,18 +1,14 @@
-import { Entity, PrimaryColumn, Generated, ManyToOne, JoinColumn } from 'typeorm';
+import { Entity, ManyToOne, JoinColumn } from 'typeorm';
 import Recipe from '../recipe/recipe.entity';
 import Tag from '../tag/tag.entity';
 
 @Entity({ name: 'RECIPE_TAG' })
 export default class RecipeTag {
-	@PrimaryColumn({ name: 'RECIPE_TAG_ID', type: 'bigint', unsigned: true })
-	@Generated('increment')
-	id: number;
-
-	@ManyToOne(() => Recipe, (recipe) => recipe.id, { lazy: true, nullable: false })
+	@ManyToOne(() => Recipe, (recipe) => recipe.tags, { lazy: true, nullable: false, primary: true })
 	@JoinColumn({ name: 'RECIPE_ID' })
 	recipe: Recipe;
 
-	@ManyToOne(() => Tag, (tag) => tag.id, { lazy: true, nullable: false })
+	@ManyToOne(() => Tag, (tag) => tag.recipes, { lazy: true, nullable: false, primary: true })
 	@JoinColumn({ name: 'TAG_ID' })
 	tag: Tag;
 }

--- a/src/recipe/recipe.entity.ts
+++ b/src/recipe/recipe.entity.ts
@@ -1,7 +1,7 @@
 import { Entity, PrimaryColumn, Generated, ManyToOne, JoinColumn, Column, OneToMany } from 'typeorm';
 
 import { Date } from '../entity/date.entity';
-import Description from '../recipe-description/description.entity';
+import Description from '../recipe-description/recipe-description.entity';
 import RecipeIngredient from '../recipe-ingredient/recipe-ingredient.entity';
 import RecipeTag from '../recipe-tag/recipe-tag.entity';
 import User from '../user/user.entity';

--- a/src/recipe/recipe.entity.ts
+++ b/src/recipe/recipe.entity.ts
@@ -1,10 +1,10 @@
 import { Entity, PrimaryColumn, Generated, ManyToOne, JoinColumn, Column, OneToMany } from 'typeorm';
 
 import { Date } from '../entity/date.entity';
+import Description from '../recipe-description/description.entity';
+import RecipeIngredient from '../recipe-ingredient/recipe-ingredient.entity';
 import RecipeTag from '../recipe-tag/recipe-tag.entity';
 import User from '../user/user.entity';
-import RecipeIngredient from '../recipe-ingredient/recipe-ingredient';
-import Description from '../recipe-description/description';
 
 enum serving {
 	DONTKNOW = 0,
@@ -22,17 +22,17 @@ export default class Recipe extends Date {
 	id: number;
 
 	@ManyToOne(() => User, (user) => user.recipes, { nullable: false, lazy: true })
-	@JoinColumn({ name: 'USER_ID', referencedColumnName: 'id' })
+	@JoinColumn({ name: 'USER_ID' })
 	user: User;
 
 	@OneToMany(() => Description, (description) => description.recipe, { lazy: true })
-	descriptions: Description[] = [];
+	descriptions: Description[];
 
 	@OneToMany(() => RecipeIngredient, (recipeIngredient) => recipeIngredient.recipe, { lazy: true })
-	recipeIngredients: RecipeIngredient[] = [];
+	ingredients: RecipeIngredient[];
 
 	@OneToMany(() => RecipeTag, (recipeTag) => recipeTag.recipe, { lazy: true })
-	recipeTags: RecipeTag[] = [];
+	tags: RecipeTag[];
 
 	@Column({ name: 'THUMBNAIL_URL', type: 'varchar', length: 2048, nullable: false })
 	thumbnailUrl: string;

--- a/src/subscribe/subscribe.entity.ts
+++ b/src/subscribe/subscribe.entity.ts
@@ -1,17 +1,13 @@
-import { Entity, PrimaryColumn, Generated, ManyToOne, JoinColumn } from 'typeorm';
+import { Entity, ManyToOne, JoinColumn } from 'typeorm';
 import User from '../user/user.entity';
 
 @Entity({ name: 'SUBSCRIBE' })
 export default class Subscribe {
-	@PrimaryColumn({ name: 'SUBSCRIBE,ID', type: 'bigint', unsigned: true })
-	@Generated('increment')
-	id: number;
-
-	@ManyToOne(() => User, (user) => user.id, { lazy: true, nullable: false, primary: true })
+	@ManyToOne(() => User, (user) => user.subscribers, { lazy: true, nullable: false, primary: true })
 	@JoinColumn({ name: 'SUBSCRIBER_ID' })
 	subscriber: User;
 
-	@ManyToOne(() => User, (user) => user.id, { lazy: true, nullable: false, primary: true })
+	@ManyToOne(() => User, (user) => user.publishers, { lazy: true, nullable: false, primary: true })
 	@JoinColumn({ name: 'PUBLISHER_ID' })
 	publisher: User;
 }

--- a/src/tag/tag.entity.ts
+++ b/src/tag/tag.entity.ts
@@ -8,9 +8,9 @@ export default class Tag {
 	@Generated('increment')
 	id: number;
 
+	@OneToMany(() => RecipeTag, (recipeTag) => recipeTag.tag, { lazy: true })
+	recipes: RecipeTag[];
+
 	@Column({ name: 'NAME', length: 24, nullable: false })
 	name: string;
-
-	@OneToMany(() => RecipeTag, (recipeTag) => recipeTag.tag, { lazy: true })
-	recipeTags: RecipeTag[];
 }

--- a/src/user/user.entity.ts
+++ b/src/user/user.entity.ts
@@ -28,16 +28,16 @@ export default class User extends Date {
 	id: number;
 
 	@OneToMany(() => Recipe, (recipe) => recipe.id, { lazy: true })
-	recipes: Recipe[] = [];
+	recipes: Recipe[];
 
-	@OneToMany(() => Bookmark, (bookmark) => bookmark.recipe, { lazy: true })
-	bookmarks: Bookmark[] = [];
-
-	@OneToMany(() => Subscribe, (subscribe) => subscribe.publisher, { lazy: true })
-	publishers: User[] = [];
+	@OneToMany(() => Bookmark, (bookmark) => bookmark.user, { lazy: true })
+	bookmarks: Bookmark[];
 
 	@OneToMany(() => Subscribe, (subscribe) => subscribe.publisher, { lazy: true })
-	subscribers: User[] = [];
+	publishers: User[];
+
+	@OneToMany(() => Subscribe, (subscribe) => subscribe.subscriber, { lazy: true })
+	subscribers: User[];
 
 	@Column({
 		name: 'LOGIN_ID',


### PR DESCRIPTION
# entity 연관관계 개선
- 쿼리를 작성하면서, Entity 연관관계가 잘못 설정되어있다는 것을 깨닫고 Entity 연관관계를 수정했습니다
- JPA와 달리 단방향 연관관계 설정이 불가능한 듯합니다

# entity 분리
- M:N 관계를 표현하기 위해 생성된 Table에 대응되는 Entity를 별도의 폴더로 분리했습니다
- 추후 확장성을 위해 분리했습니다