### PR TITLE
feat : 유저 검색 구현

### DIFF
--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -22,21 +22,21 @@ export default class UserController implements AbstractUserController {
 	initRouter(app: express.Application): void {
 		if (UserController.instance) return;
 
-		UserController.router.get('/search', this.getUserByNickname);
-		UserController.router.get('/:id', this.getUserById);
+		UserController.router.get('/search', this.getByNickname);
+		UserController.router.get('/:id', this.getById);
 
 		app.use(UserController.PATH, UserController.router);
 	}
 
-	async getUserById(req: Request, res: Response): Promise<void> {
+	async getById(req: Request, res: Response): Promise<void> {
 		const id = Number(req.params.id);
-		const findUser = await UserController.userService.findUserById(id);
+		const findUser = await UserController.userService.findById(id);
 		res.send(findUser);
 	}
 
-	async getUserByNickname(req: Request, res: Response): Promise<void> {
+	async getByNickname(req: Request, res: Response): Promise<void> {
 		const nickname = String(req.query.nickname);
-		const findUser = await UserController.userService.findUserByNickname(nickname);
-		res.send(findUser);
+		const findUsers = await UserController.userService.findByNickname(nickname);
+		res.send(findUsers);
 	}
 }

--- a/src/user/user.d.ts
+++ b/src/user/user.d.ts
@@ -2,6 +2,7 @@ import { EntityManager } from 'typeorm';
 import express, { Request, Response, Router } from 'express';
 
 import User from './user.entity';
+import Recipe from '../recipe/recipe.entity';
 
 export abstract class AbstractUserRepository {
 	private static instance: AbstractUserRepository;
@@ -10,8 +11,9 @@ export abstract class AbstractUserRepository {
 	public static getInstance(em: EntityManager): AbstractUserRepository;
 	private constructor(em: EntityManager);
 
-	findUserById(id: number): Promise<Partial<User>>;
-	findUserByNickname(nickname: string): Promise<Partial<User>[]>;
+	findById(id: number): Promise<Partial<User>>;
+	findByNickname(nickname: string): Promise<Partial<User>[]>;
+	findBeLovedRecipe(id: number): Promise<Partial<Recipe>[]>;
 }
 
 export abstract class AbstractUserService {
@@ -21,8 +23,8 @@ export abstract class AbstractUserService {
 	public static getInstance(userRepository: AbstractUserRepository): AbstractUserService;
 	private constructor(userRepository: AbstractUserRepository);
 
-	findUserById(id: number): Promise<Partial<User>>;
-	findUserByNickname(nickname: string): Promise<Partial<User>[]>;
+	findById(id: number): Promise<BasicInfomationWithList>;
+	findByNickname(nickname: string): Promise<BasicInfomation[]>;
 }
 
 export abstract class AbstractUserController {
@@ -35,6 +37,18 @@ export abstract class AbstractUserController {
 	private constructor(userService: AbstractUserService, app: express.Application);
 	initRouter(app: express.Application): void;
 
-	getUserById(req: Request, res: Response): Promise<void>;
-	getUserByNickname(req: Request, res: Response): Promise<void>;
+	getById(req: Request, res: Response): Promise<void>;
+	getByNickname(req: Request, res: Response): Promise<void>;
+}
+
+export interface BasicInfomation {
+	user: Partial<User>;
+	numberOfFans: number;
+	numberOfLikes: number;
+}
+
+export interface BasicInfomationWithList extends BasicInfomation {
+	recipes: Partial<Recipe>[];
+	likeRecipes: Partial<Recipe>[];
+	subscribingUsers: Partial<User>[];
 }

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -2,11 +2,13 @@ import { EntityManager } from 'typeorm';
 
 import { AbstractUserRepository } from './user';
 import User from './user.entity';
+import Recipe from '../recipe/recipe.entity';
+import Bookmark from '../bookmark/bookmark.entity';
 
 export default class UserRepository implements AbstractUserRepository {
 	private static instance: AbstractUserRepository;
 	private static em: EntityManager;
-	private static PUBLIC_INFO = ['user.id', 'user.nickname', 'user.thumbnailUrl', 'user.description', 'user.grade'];
+	private static PUBLIC_USER_INFO = ['user.id', 'user.nickname', 'user.thumbnailUrl', 'user.description', 'user.grade'];
 
 	public static getInstance(em: EntityManager): AbstractUserRepository {
 		if (!UserRepository.instance) {
@@ -19,23 +21,35 @@ export default class UserRepository implements AbstractUserRepository {
 		UserRepository.em = em;
 	}
 
-	async findUserById(id: number): Promise<Partial<User>> {
+	async findById(id: number): Promise<Partial<User>> {
 		const findResult = await UserRepository.em
 			.getRepository(User)
 			.createQueryBuilder('user')
-			.select(UserRepository.PUBLIC_INFO)
+			.select(UserRepository.PUBLIC_USER_INFO)
 			.where('user.id=:id', { id })
 			.getOne();
 		return findResult;
 	}
 
-	async findUserByNickname(nickname: string): Promise<Partial<User>[]> {
+	async findByNickname(nickname: string): Promise<Partial<User>[]> {
 		const findResultList = await UserRepository.em
 			.getRepository(User)
 			.createQueryBuilder('user')
-			.select(UserRepository.PUBLIC_INFO)
+			.select(UserRepository.PUBLIC_USER_INFO)
 			.where('user.nickname = :nickname', { nickname })
 			.getMany();
 		return findResultList;
+	}
+
+	// 좋아요가 눌린 내 Recipe 검색
+	async findBeLovedRecipe(id: number): Promise<Partial<Recipe>[]> {
+		const findRecipes = await UserRepository.em
+			.getRepository(Bookmark)
+			.createQueryBuilder('bookmark')
+			.select(['recipe'])
+			.innerJoin('bookmark.recipe', 'recipe')
+			.where('recipe.user = :id', { id })
+			.execute();
+		return findRecipes;
 	}
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,5 +1,6 @@
 import { AbstractUserRepository, AbstractUserService } from './user';
-import User from './user.entity';
+
+import { BasicInfomation, BasicInfomationWithList } from './user';
 
 export default class UserService implements AbstractUserService {
 	private static instance: AbstractUserService;
@@ -16,13 +17,39 @@ export default class UserService implements AbstractUserService {
 		UserService.userRepository = userRepository;
 	}
 
-	async findUserById(id: number): Promise<Partial<User>> {
-		const findUser = await UserService.userRepository.findUserById(id);
-		return findUser;
+	async findById(id: number): Promise<BasicInfomationWithList> {
+		const findUser = await UserService.userRepository.findById(id);
+		const fans = await findUser.fans;
+		const recipes = await findUser.recipes;
+		const likeRecipes = await findUser.bookmarks;
+		const likedRecipes = await UserService.userRepository.findBeLovedRecipe(id);
+		const subscribingUsers = await findUser.stars;
+
+		return {
+			user: findUser,
+			numberOfFans: fans.length,
+			numberOfLikes: likedRecipes.length,
+			recipes,
+			likeRecipes,
+			subscribingUsers,
+		};
 	}
 
-	async findUserByNickname(nickname: string): Promise<Partial<User>[]> {
-		const findUserList = await UserService.userRepository.findUserByNickname(nickname);
-		return findUserList;
+	async findByNickname(nickname: string): Promise<BasicInfomation[]> {
+		const findUsers = await UserService.userRepository.findByNickname(nickname);
+		const UserBasicInfomation = Promise.all(
+			findUsers.map(async (user) => {
+				const numberOfFans = (await user.fans).length;
+				const numberOfLikes = (await UserService.userRepository.findBeLovedRecipe(user.id)).length;
+
+				return {
+					user: user,
+					numberOfFans,
+					numberOfLikes,
+				};
+			})
+		);
+
+		return UserBasicInfomation;
 	}
 }


### PR DESCRIPTION
유저 검색을 구현, 리펙토링 했습니다

기존에는 모든 유저 데이터를 전송했는데, 거기에 id, password 등 민감한 정보가 담겨있어서 제외시켰습니다

id 검색, nickname 검색이 요구하는 데이터 타입이 다릅니다 (API 명세서 참고)

eager loading을 도입해서 쿼리 성능을 개선해봐야겠습니다