### PR TITLE
Feat#51 user thumbnail url update

### DIFF
--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -24,10 +24,22 @@ export default class UserController implements AbstractUserController {
 
 		UserController.router.get('/search', this.getByNickname);
 		UserController.router.get('/:id', this.getById);
-		UserController.router.put('/:id', this.updateById);
-		UserController.router.get('/:id/thumbnail', this.deleteThumbnail);
+		UserController.router.patch('/:id', this.updateById);
+		UserController.router.delete('/:id/thumbnail', this.deleteThumbnail);
+		UserController.router.patch('/:id/thumbnail', this.updateThumbnail);
 
 		app.use(UserController.PATH, UserController.router);
+	}
+
+	async updateThumbnail(req: Request, res: Response): Promise<void> {
+		try {
+			const id = Number(req.params.id);
+			const { thumbnailUrl } = req.body;
+			await UserController.userService.updateThumbnail(id, thumbnailUrl);
+			res.status(200).send();
+		} catch (error) {
+			res.status(400).send();
+		}
 	}
 
 	async deleteThumbnail(req: Request, res: Response): Promise<void> {

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -25,8 +25,19 @@ export default class UserController implements AbstractUserController {
 		UserController.router.get('/search', this.getByNickname);
 		UserController.router.get('/:id', this.getById);
 		UserController.router.put('/:id', this.updateById);
+		UserController.router.get('/:id/thumbnail', this.deleteThumbnail);
 
 		app.use(UserController.PATH, UserController.router);
+	}
+
+	async deleteThumbnail(req: Request, res: Response): Promise<void> {
+		try {
+			const id = Number(req.params.id);
+			await UserController.userService.deleteThumbnail(id);
+			res.status(200).send();
+		} catch (error) {
+			res.status(400).send();
+		}
 	}
 
 	async updateById(req: Request, res: Response): Promise<void> {

--- a/src/user/user.d.ts
+++ b/src/user/user.d.ts
@@ -11,8 +11,9 @@ export abstract class AbstractUserRepository {
 	public static getInstance(em: EntityManager): AbstractUserRepository;
 	private constructor(em: EntityManager);
 
+	updateThumbnail(id: number, thumbnailUrl: string): Promise<void>;
 	deleteThumbnail(id: number): Promise<void>;
-	updateById(id: number, body: UpdateBody): Promise<void>;
+	updateById(id: number, body: UpdateUserBody): Promise<void>;
 	findById(id: number): Promise<Partial<User>>;
 	findByNickname(nickname: string): Promise<Partial<User>[]>;
 	findBeLovedRecipe(id: number): Promise<Partial<Recipe>[]>;
@@ -25,8 +26,9 @@ export abstract class AbstractUserService {
 	public static getInstance(userRepository: AbstractUserRepository): AbstractUserService;
 	private constructor(userRepository: AbstractUserRepository);
 
+	updateThumbnail(id: number, thumbnailUrl: string): Promise<void>;
 	deleteThumbnail(id: number): Promise<void>;
-	updateById(id: number, body: UpdateBody): Promise<void>;
+	updateById(id: number, body: UpdateUserBody): Promise<void>;
 	findById(id: number): Promise<BasicInfomationWithList>;
 	findByNickname(nickname: string): Promise<BasicInfomation[]>;
 }
@@ -41,6 +43,7 @@ export abstract class AbstractUserController {
 	private constructor(userService: AbstractUserService, app: express.Application);
 	initRouter(app: express.Application): void;
 
+	updateThumbnail(req: Request, res: Response): Promise<void>;
 	deleteThumbnail(req: Request, res: Response): Promise<void>;
 	updateById(req: Request, res: Response): Promise<void>;
 	getById(req: Request, res: Response): Promise<void>;
@@ -59,7 +62,7 @@ export interface BasicInfomationWithList extends BasicInfomation {
 	subscribingUsers: Partial<User>[];
 }
 
-export interface UpdateBody {
+export interface UpdateUserBody {
 	nickname: string;
 	loginPassword: string;
 	confirmPassword: string;

--- a/src/user/user.d.ts
+++ b/src/user/user.d.ts
@@ -11,6 +11,7 @@ export abstract class AbstractUserRepository {
 	public static getInstance(em: EntityManager): AbstractUserRepository;
 	private constructor(em: EntityManager);
 
+	deleteThumbnail(id: number): Promise<void>;
 	updateById(id: number, body: UpdateBody): Promise<void>;
 	findById(id: number): Promise<Partial<User>>;
 	findByNickname(nickname: string): Promise<Partial<User>[]>;
@@ -24,6 +25,7 @@ export abstract class AbstractUserService {
 	public static getInstance(userRepository: AbstractUserRepository): AbstractUserService;
 	private constructor(userRepository: AbstractUserRepository);
 
+	deleteThumbnail(id: number): Promise<void>;
 	updateById(id: number, body: UpdateBody): Promise<void>;
 	findById(id: number): Promise<BasicInfomationWithList>;
 	findByNickname(nickname: string): Promise<BasicInfomation[]>;
@@ -39,6 +41,7 @@ export abstract class AbstractUserController {
 	private constructor(userService: AbstractUserService, app: express.Application);
 	initRouter(app: express.Application): void;
 
+	deleteThumbnail(req: Request, res: Response): Promise<void>;
 	updateById(req: Request, res: Response): Promise<void>;
 	getById(req: Request, res: Response): Promise<void>;
 	getByNickname(req: Request, res: Response): Promise<void>;

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -1,6 +1,6 @@
 import { EntityManager } from 'typeorm';
 
-import { AbstractUserRepository, UpdateBody } from './user';
+import { AbstractUserRepository, UpdateUserBody } from './user';
 import User from './user.entity';
 import Recipe from '../recipe/recipe.entity';
 import Bookmark from '../bookmark/bookmark.entity';
@@ -21,11 +21,15 @@ export default class UserRepository implements AbstractUserRepository {
 		UserRepository.em = em;
 	}
 
+	async updateThumbnail(id: number, thumbnailUrl: string): Promise<void> {
+		await UserRepository.em.createQueryBuilder().update(User).set({ thumbnailUrl }).where('id = :id', { id }).execute();
+	}
+
 	async deleteThumbnail(id: number): Promise<void> {
 		await UserRepository.em.createQueryBuilder().update(User).set({ thumbnailUrl: 'empty' }).where('id = :id', { id }).execute();
 	}
 
-	async updateById(id: number, body: UpdateBody): Promise<void> {
+	async updateById(id: number, body: UpdateUserBody): Promise<void> {
 		await UserRepository.em
 			.createQueryBuilder()
 			.update(User)

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -21,9 +21,12 @@ export default class UserRepository implements AbstractUserRepository {
 		UserRepository.em = em;
 	}
 
+	async deleteThumbnail(id: number): Promise<void> {
+		await UserRepository.em.createQueryBuilder().update(User).set({ thumbnailUrl: 'empty' }).where('id = :id', { id }).execute();
+	}
+
 	async updateById(id: number, body: UpdateBody): Promise<void> {
 		await UserRepository.em
-			.getRepository(User)
 			.createQueryBuilder()
 			.update(User)
 			.set({ nickname: body.nickname, loginPassword: body.loginPassword, description: body.description })

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -17,10 +17,15 @@ export default class UserService implements AbstractUserService {
 		UserService.userRepository = userRepository;
 	}
 
+	async deleteThumbnail(id: number): Promise<void> {
+		await UserService.userRepository.deleteThumbnail(id);
+	}
+
 	async updateById(id: number, body: UpdateBody): Promise<void> {
 		if (body.loginPassword !== body.confirmPassword) {
 			throw new Error('비밀번호가 다릅니다');
 		}
+		// password 암호화 필요
 		await UserService.userRepository.updateById(id, body);
 	}
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,4 +1,4 @@
-import { AbstractUserRepository, AbstractUserService, UpdateBody } from './user';
+import { AbstractUserRepository, AbstractUserService, UpdateUserBody } from './user';
 
 import { BasicInfomation, BasicInfomationWithList } from './user';
 
@@ -17,11 +17,15 @@ export default class UserService implements AbstractUserService {
 		UserService.userRepository = userRepository;
 	}
 
+	async updateThumbnail(id: number, thumbnailUrl: string): Promise<void> {
+		await UserService.userRepository.updateThumbnail(id, thumbnailUrl);
+	}
+
 	async deleteThumbnail(id: number): Promise<void> {
 		await UserService.userRepository.deleteThumbnail(id);
 	}
 
-	async updateById(id: number, body: UpdateBody): Promise<void> {
+	async updateById(id: number, body: UpdateUserBody): Promise<void> {
 		if (body.loginPassword !== body.confirmPassword) {
 			throw new Error('비밀번호가 다릅니다');
 		}


### PR DESCRIPTION
## 유저 썸네일 삭제
- DB의 User Table에서, thumbnailURL에 `empty`를 삽입

## 유저 썸네일 업로드
- 브라우저에서, S3에 직접 image 파일을 전송
- S3에서 url을 발급받음
- 발급받은 url을 서버로 전송
