### PR TITLE
Feat#54 : update recipe 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ dist
 
 build
 .rest
+.DS_Store

--- a/src/container.ts
+++ b/src/container.ts
@@ -30,6 +30,7 @@ import IngredientRepository from './ingredient/ingredient.repository';
 import RecipeTagRepository from './recipeTag/recipeTag.repository';
 import RecipeIngredientRepository from './recipeIngredient/recipeIngredient.repository';
 import BookmarkRepository from './bookmark/bookmark.repository';
+import RecipeDescriptionRepository from './recipeDescription/recipeDescription.repository';
 
 export default class Container {
 	private static isInitialzied = false;
@@ -106,6 +107,7 @@ export default class Container {
 			recipeTagRepository: Container.getBean(layer.REPOSITORY, domain.RECIPE_TAG),
 			recipeIngredientRepository: Container.getBean(layer.REPOSITORY, domain.RECIPE_INGREDIENT),
 			bookmarkRepository: Container.getBean(layer.REPOSITORY, domain.BOOKMAKR),
+			recipeDescriptionRepository: Container.getBean(layer.REPOSITORY, domain.RECIPE_DESCRIPTION),
 		});
 		//Container.bean[layer.SERVICE][domain.RECIPE_TAG] =
 		//Container.bean[layer.SERVICE][domain.RECIPE_INGREDIENT] =
@@ -126,7 +128,7 @@ export default class Container {
 		Container.bean[layer.REPOSITORY][domain.RECIPE] = RecipeRepository.getInstance({ ...commonDependency });
 		Container.bean[layer.REPOSITORY][domain.RECIPE_TAG] = RecipeTagRepository.getInstance({ ...commonDependency });
 		Container.bean[layer.REPOSITORY][domain.RECIPE_INGREDIENT] = RecipeIngredientRepository.getInstance({ ...commonDependency });
-		//Container.bean[layer.REPOSITORY][domain.RECIPE_DESCRIPTION] =
+		Container.bean[layer.REPOSITORY][domain.RECIPE_DESCRIPTION] = RecipeDescriptionRepository.getInstance({ ...commonDependency });
 		Container.bean[layer.REPOSITORY][domain.INGREDIENT] = IngredientRepository.getInstance({ ...commonDependency });
 		//Container.bean[layer.REPOSITORY][domain.DATEINFO] =
 		Container.bean[layer.REPOSITORY][domain.BOOKMAKR] = BookmarkRepository.getInstance({ ...commonDependency });

--- a/src/recipeDescription/recipeDescription.entity.ts
+++ b/src/recipeDescription/recipeDescription.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, ManyToOne, Column, PrimaryColumn, Generated, JoinColumn } from 'typeorm';
+import { Entity, ManyToOne, Column, JoinColumn } from 'typeorm';
 
 import Recipe from '../recipe/recipe.entity';
 
@@ -6,11 +6,7 @@ import { ModifyRecipeDescriptionDTO } from './type/type';
 
 @Entity({ name: 'RECIPE_DESCRIPTION' })
 export default class RecipeDescription {
-	@PrimaryColumn({ name: 'RECIPE_DESCRIPTION_ID', type: 'bigint', unsigned: true })
-	@Generated('increment')
-	id: number;
-
-	@ManyToOne(() => Recipe, (recipe) => recipe.recipeDescriptions, { lazy: true })
+	@ManyToOne(() => Recipe, (recipe) => recipe.recipeDescriptions, { lazy: true, primary: true })
 	@JoinColumn({ name: 'RECIPE_ID' })
 	recipe: Recipe;
 

--- a/src/recipeDescription/recipeDescription.repository.ts
+++ b/src/recipeDescription/recipeDescription.repository.ts
@@ -1,0 +1,23 @@
+import { EntityManager } from 'typeorm';
+import RecipeDescription from './recipeDescription.entity';
+
+import { AbstractRecipeDescriptionRepository } from './type/recipeDescriptionRepository';
+
+export default class RecipeDescriptionRepository implements AbstractRecipeDescriptionRepository {
+	private static instance: AbstractRecipeDescriptionRepository;
+	private static em: EntityManager;
+
+	public static getInstance(dependency): AbstractRecipeDescriptionRepository {
+		if (!RecipeDescriptionRepository.instance) {
+			RecipeDescriptionRepository.instance = new RecipeDescriptionRepository(dependency);
+		}
+		return RecipeDescriptionRepository.instance;
+	}
+	private constructor(dependency) {
+		RecipeDescriptionRepository.em = dependency.em;
+	}
+
+	async delete(recipeDescription: RecipeDescription): Promise<void> {
+		await RecipeDescriptionRepository.em.delete(RecipeDescription, recipeDescription);
+	}
+}

--- a/src/recipeDescription/type/recipeDescriptionRepository.d.ts
+++ b/src/recipeDescription/type/recipeDescriptionRepository.d.ts
@@ -1,0 +1,13 @@
+import { EntityManager } from 'typeorm';
+
+import RecipeDescription from '../recipeDescription.entity';
+
+export class AbstractRecipeDescriptionRepository {
+	private static instance: AbstractRecipeDescriptionRepository;
+	private static em: EntityManager;
+
+	public static getInstance(dependency): AbstractRecipeDescriptionRepository;
+	private constructor(dependency);
+
+	delete(recipeDescription: RecipeDescription): Promise<void>;
+}

--- a/src/recipeIngredient/recipeIngredient.repository.ts
+++ b/src/recipeIngredient/recipeIngredient.repository.ts
@@ -23,4 +23,8 @@ export default class RecipeIngredientRepository implements AbstractRecipeIngredi
 	async findAll(): Promise<recipeIngredientEntity[]> {
 		return await RecipeIngredientRepository.em.getRepository(RecipeIngredient).find();
 	}
+
+	async delete(recipeIngredient: RecipeIngredient): Promise<void> {
+		await RecipeIngredientRepository.em.delete(RecipeIngredient, recipeIngredient);
+	}
 }

--- a/src/recipeIngredient/type/recipeIngredientRepository.d.ts
+++ b/src/recipeIngredient/type/recipeIngredientRepository.d.ts
@@ -11,4 +11,6 @@ export class AbstractRecipeIngredientRepository {
 	private constructor(dependency);
 
 	findAll(): Promise<RecipeIngredient[]>;
+
+	delete(recipeIngredient: RecipeIngredient): Promise<void>;
 }

--- a/src/recipeTag/recipeTag.repository.ts
+++ b/src/recipeTag/recipeTag.repository.ts
@@ -22,4 +22,8 @@ export default class RecipeTagRepository implements AbstractRecipeTagRepository 
 	async findAll(): Promise<RecipeTag[]> {
 		return await RecipeTagRepository.em.getRepository(RecipeTag).find();
 	}
+
+	async delete(recipeTag: RecipeTag): Promise<void> {
+		await RecipeTagRepository.em.delete(RecipeTag, recipeTag);
+	}
 }

--- a/src/recipeTag/type/recipeTagRepository.d.ts
+++ b/src/recipeTag/type/recipeTagRepository.d.ts
@@ -10,4 +10,6 @@ export class AbstractRecipeTagRepository {
 	private constructor(dependency);
 
 	findAll(): Promise<RecipeTag[]>;
+
+	delete(recipeTag: RecipeTag): Promise<void>;
 }

--- a/src/user/type/userRepository.d.ts
+++ b/src/user/type/userRepository.d.ts
@@ -2,7 +2,7 @@ import { EntityManager } from 'typeorm';
 
 import User from '../user.entity';
 
-import { UpdateUserInfomation } from './type';
+import { UpdateUserDTO } from './type';
 
 export abstract class AbstractUserRepository {
 	private static instance: AbstractUserRepository;
@@ -13,7 +13,7 @@ export abstract class AbstractUserRepository {
 
 	save(user: User): Promise<void>;
 
-	updateUserInfomation(id: number, updateUserInfomation: UpdateUserInfomation): Promise<void>;
+	updateUserInfomation(id: number, updateUserInfomation: UpdateUserDTO): Promise<void>;
 	updateThumbnail(id: number, thumbnailUrl: string): Promise<void>;
 
 	deleteThumbnail(id: number): Promise<void>;


### PR DESCRIPTION
#54 

1. ingredient & recipeIngredient
2. tag & recipeTag
3. recipeDescription
에 대해 업데이트 방식을 고민했음

원래 의도 : PK를 이용해서, 기존 레코드를 식별한 뒤, 실제로 변한 부분만 update
실제 구현 : 기존 레코드를 전부 삭제한 뒤, 새로운 레코드를 생성후 연관관계 연결

결론 : 성능 개선 필요