### PR TITLE
Fix#testing btcrypt environment

### DIFF
--- a/src/user/entity.ts
+++ b/src/user/entity.ts
@@ -73,7 +73,7 @@ export default class User {
 	@Column({
 		name: 'DESCRIPTION',
 		type: 'varchar',
-		default: '안녕하세요!',
+		default: 'hello!',
 		length: 900,
 		nullable: false,
 	})

--- a/src/user/service.ts
+++ b/src/user/service.ts
@@ -30,9 +30,15 @@ export default class UserService implements AbsUserService {
 		const hash = await bcrypt.hash(loginPassword, SALT_ROUNDS);
 		return hash;
 	}
-
-	// comparePassword(loginPassword:string): Promise<void>
-
+/*
+	async comparePassword(password:string, hashedpassword:string): Promise<boolean> {
+		bcrypt.compare(password, hashedpassword).then(function(result) {
+			if(result) {
+				return true;
+			}
+		});
+	}
+*/
 	async signIn(createUserInformation: CreateUserDTO): Promise<BaseUserDTO | Error> {
 		if (createUserInformation.loginPassword !== createUserInformation.confirmPassword)
 			throw new Error(UserError.PASSWORD_NOT_MATCH.message);
@@ -83,9 +89,14 @@ export default class UserService implements AbsUserService {
 
 		const user = await UserService.userRepository.findById(targetUserId);
 		if (!user) throw new Error(UserError.NOT_FOUND.message);
+		
+		// 비밀번호를 변경하지 않았을 때에도 암호화 할 것인지 고민
+		const encodedPassword  = await this.bcryptPassword(updateUserInfomation.loginPassword);
 
-		user.nickname = updateUserInfomation.nickname;
+		updateUserInfomation.loginPassword = encodedPassword;
+
 		user.loginPassword = updateUserInfomation.loginPassword;
+		user.nickname = updateUserInfomation.nickname;
 		user.description = updateUserInfomation.description;
 
 		await UserService.userRepository.save(user);

--- a/src/user/type/dto.ts
+++ b/src/user/type/dto.ts
@@ -41,10 +41,10 @@ export class ReadUserDetailDTO extends ReadUserDTO {
 }
 
 export class UpdateUserDTO {
-	readonly nickname: string;
+	public nickname: string;
 	public loginPassword: string;
 	readonly confirmPassword: string;
-	readonly description: string;
+	public description: string;
 }
 
 export class CreateUserDTO {

--- a/src/user/type/dto.ts
+++ b/src/user/type/dto.ts
@@ -42,13 +42,13 @@ export class ReadUserDetailDTO extends ReadUserDTO {
 
 export class UpdateUserDTO {
 	readonly nickname: string;
-	readonly loginPassword: string;
+	public loginPassword: string;
 	readonly confirmPassword: string;
 	readonly description: string;
 }
 
 export class CreateUserDTO {
 	readonly loginId: string;
-	readonly loginPassword: string;
+	public loginPassword: string;
 	readonly confirmPassword: string;
 }

--- a/src/user/type/service.d.ts
+++ b/src/user/type/service.d.ts
@@ -9,8 +9,15 @@ export abstract class AbsUserService {
 	public static getInstance(dependency): AbsUserService;
 	private constructor(dependency);
 
+	bcryptPassword(loginPassword: string): Promise<string>;
+	//comparePassword(loginPassword:string, confirmPassword: string): Promise<void | Error>;
+
 	signIn(createUserInformation: CreateUserDTO): Promise<BaseUserDTO | Error>;
 	signOut(userId: number): Promise<void | Error>;
+
+	// logIn()
+	// logOut()
+	// middleware
 
 	findById(id: number): Promise<ReadUserDetailDTO | Error>;
 	findByNickname(nickname: string): Promise<ReadUserDTO[] | Error>;

--- a/src/user/type/service.d.ts
+++ b/src/user/type/service.d.ts
@@ -10,7 +10,7 @@ export abstract class AbsUserService {
 	private constructor(dependency);
 
 	bcryptPassword(loginPassword: string): Promise<string>;
-	//comparePassword(loginPassword:string, confirmPassword: string): Promise<void | Error>;
+	//comparePassword(loginPassword:string, confirmPassword: string): Promise<boolean>;
 
 	signIn(createUserInformation: CreateUserDTO): Promise<BaseUserDTO | Error>;
 	signOut(userId: number): Promise<void | Error>;


### PR DESCRIPTION
회원가입 및 회원 정보 변경시 비밀번호 암호화 설정 완료
-  user entity 에서 'discription'은 제가 구름 ide 로 새로 환경설정해서 진행하고 있는데 거기에서 한글 인코딩이 안되어서 잠시 영어로 바꾸었습니다! ㅠㅠ 
- dto 부분에서는 readonly 설정으로 값이 변경이 안되어서 public으로 바꾼 상황입니다! 찾아보니 public으로 바꾸면 안좋다는 말도 나와 있어서 혹 문제가 발생하면 수정하도록 하겠습니다! 